### PR TITLE
Remove card attribute for vertical tabs

### DIFF
--- a/template.php
+++ b/template.php
@@ -281,8 +281,8 @@ function bootstrap5_lite_fieldset($variables) {
   $element = $variables['element'];
   element_set_attributes($element, array('id'));
   _form_set_class($element, array('form-wrapper'));
-  $element['#attributes']['class'][] = 'card';
-  $element['#attributes']['class'][] = 'card-default';
+  // $element['#attributes']['class'][] = 'card';
+  // $element['#attributes']['class'][] = 'card-default';
   $output = '<fieldset' . backdrop_attributes($element['#attributes']) . '>';
   if (!empty($element['#title'])) {
     // Always wrap fieldset legends in a SPAN for CSS positioning.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bootstrap5_lite/issues/19.

These classes  conflict with class "vertical-tabs-pane" and break vertical tabs behavior.