### PR TITLE
Issue #55: Close media query in overrides.css.

### DIFF
--- a/css/overrides.css
+++ b/css/overrides.css
@@ -378,10 +378,10 @@ span.password-toggle-wrapper {
     grid-template-columns: repeat(3, 1fr);
     gap: 2rem;
   }
+}
 
 .messages .placeholder {
   background-color: transparent;
-
 }
 
 /* Overrides dropbutton a colors for all Bootswatch themes */


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bootstrap5_lite/issues/55.