### PR TITLE
Issue #56: Fix Bootstrap CDN address.

### DIFF
--- a/theme-settings.php
+++ b/theme-settings.php
@@ -29,7 +29,7 @@ function bootstrap5_lite_form_system_theme_settings_alter(&$form, &$form_state, 
     '#type' => 'fieldset',
     '#title' => t('Version and CDN'),
     '#description' => t('You may use the !bootstrapcdn or choose the bundled library to serve the Bootstrap framework files. If you disable these settings, you must provide your own Bootstrap source and/or optional CDN delivery implementation. !warning', array(
-      '!bootstrapcdn' => l(t('Bootstrap CDN'), 'http://ww.bootstrapcdn.com', array(
+      '!bootstrapcdn' => l(t('Bootstrap CDN'), 'http://www.bootstrapcdn.com', array(
         'external' => TRUE,
       )),
       '!warning' => '<div class="alert alert-info messages info"><strong>' . t('NOTE') . ':</strong> ' . t('While the Bootstrap CDN (content distribution network) is the preferred method for providing performance gains in load time, this method does depend on using this third party service. BootstrapCDN is under no obligation or commitment to provide guaranteed up-time or service quality for this theme.') . '</div>',


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bootstrap5_lite/issues/56.